### PR TITLE
Extend build timeout to 45 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
 PalladioPipeline {
+    constraintBuildTimeLimitMinutes = 45
     deployUpdatesite 'releng/org.palladiosimulator.jdt.updatesite/target/repository'
 }


### PR DESCRIPTION
The pull request extend the build timeout to 45 minutes because the default (30 minutes as of now) is too restrictive.