### PR TITLE
Fix for Java 17

### DIFF
--- a/bundles/jamopp.parser.jdt.singlefile/src/jamopp/parser/jdt/singlefile/ReferenceConverterUtility.java
+++ b/bundles/jamopp.parser.jdt.singlefile/src/jamopp/parser/jdt/singlefile/ReferenceConverterUtility.java
@@ -37,6 +37,7 @@ import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
 import org.eclipse.jdt.core.dom.SuperFieldAccess;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
+import org.eclipse.jdt.core.dom.TextBlock;
 import org.eclipse.jdt.core.dom.ThisExpression;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeLiteral;
@@ -240,6 +241,13 @@ class ReferenceConverterUtility {
 			org.emftext.language.java.references.Reference parent = internalConvertToReference(arr.getType());
 			parent.setNext(result);
 			LayoutInformationConverter.convertToMinimalLayoutInformation(result, arr);
+			return result;
+		} else if (expr.getNodeType() == ASTNode.TEXT_BLOCK) {
+			TextBlock textBlock = (TextBlock) expr;
+			org.emftext.language.java.references.TextBlockReference result = org.emftext.language
+					.java.references.ReferencesFactory.eINSTANCE.createTextBlockReference();
+			result.setValue(textBlock.getEscapedValue());
+			LayoutInformationConverter.convertToMinimalLayoutInformation(result, textBlock);
 			return result;
 		}
 		return null;

--- a/tests/org.emftext.language.java.test/src/org/emftext/language/java/test/ClassFileParserTest.java
+++ b/tests/org.emftext.language.java.test/src/org/emftext/language/java/test/ClassFileParserTest.java
@@ -96,20 +96,19 @@ public class ClassFileParserTest extends AbstractJaMoPPTests {
 		parseAndReprint(folder + File.separator + "VariableReferencing.java");
 	}
 
-//	Error after switching to Java 17 and Eclipse 2022-12, needs to be investigated further
-//	@Test
-//	public void testStaticCalls() throws Exception {
-//		String registeredType = "AClass";
-//		JavaClasspath.get().registerClassifier("", registeredType,
-//				createURI(BIN_FOLDER, registeredType + CLASS_FILE_EXTENSION));
-//		JavaClasspath.get().registerClassifier(registeredType + "$", "A",
-//				createURI(BIN_FOLDER, registeredType + "$A" + CLASS_FILE_EXTENSION));
-//		registeredType = "CallTargetsProvider";
-//		String pack = "staticcalltarget";
-//		JavaClasspath.get().registerClassifier(pack, registeredType,
-//				createURI(BIN_FOLDER, pack, registeredType + CLASS_FILE_EXTENSION));
-//		parseAndReprint("StaticCalls.java");
-//	}
+	@Test
+	public void testStaticCalls() throws Exception {
+		String registeredType = "AClass";
+		JavaClasspath.get().registerClassifier("", registeredType,
+				createURI(BIN_FOLDER, registeredType + CLASS_FILE_EXTENSION));
+		JavaClasspath.get().registerClassifier(registeredType + "$", "A",
+				createURI(BIN_FOLDER, registeredType + "$A" + CLASS_FILE_EXTENSION));
+		registeredType = "CallTargetsProvider";
+		String pack = "staticcalltarget";
+		JavaClasspath.get().registerClassifier(pack, registeredType,
+				createURI(BIN_FOLDER, pack, registeredType + CLASS_FILE_EXTENSION));
+		parseAndReprint("StaticCalls.java");
+	}
 	
 	private URI createURI(String... relPath) {
 		return URI.createFileURI(Paths.get(".", relPath).toAbsolutePath().toString());


### PR DESCRIPTION
- Converts TextBlocks (new feature in Java 15) into elements of the metamodel in order fully support Java 15